### PR TITLE
use array_values to reindex the array for bulk sending

### DIFF
--- a/src/Services/Customer.php
+++ b/src/Services/Customer.php
@@ -46,7 +46,7 @@ class Customer extends Blueshift implements BlueshiftCustomer
 
     public function bulkCreateArray(array $customers): ?string
     {
-        $json = json_encode(['customers' => $customers]);
+        $json = json_encode(['customers' => array_values($customers)], JSON_THROW_ON_ERROR);
 
         return $this->createJson($json);
     }


### PR DESCRIPTION
This allows subsequent calls to bulk send array on customer to be received appropriately.